### PR TITLE
Update timelock deployment version

### DIFF
--- a/docs/modules/ROOT/pages/admin.adoc
+++ b/docs/modules/ROOT/pages/admin.adoc
@@ -113,7 +113,7 @@ You can create and deploy a new Timelock Controller directly from Defender. To c
 
 In order to verify the contract on etherscan, you can find the source code and compiler settings below:
 
-The deployment uses a vanilla instance of the https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v4.2/contracts/governance/TimelockController.sol[TimelockController contract v4.2 provided by the OpenZeppelin Contracts library].
+The deployment uses a vanilla instance of the https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6edb6dd1ca43d05a762d84c688116b3327f5e490/contracts/governance/TimelockController.sol[TimelockController contract v4.3.1 provided by the OpenZeppelin Contracts library].
 
 
 The compiler settings to deploy the contract:

--- a/docs/modules/ROOT/pages/admin.adoc
+++ b/docs/modules/ROOT/pages/admin.adoc
@@ -113,7 +113,7 @@ You can create and deploy a new Timelock Controller directly from Defender. To c
 
 In order to verify the contract on etherscan, you can find the source code and compiler settings below:
 
-The deployment uses a vanilla instance of the https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6edb6dd1ca43d05a762d84c688116b3327f5e490/contracts/governance/TimelockController.sol[TimelockController contract v4.3.1 provided by the OpenZeppelin Contracts library].
+The deployment uses a vanilla instance of the https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.3.1/contracts/governance/TimelockController.sol[TimelockController contract v4.3.1 provided by the OpenZeppelin Contracts library].
 
 
 The compiler settings to deploy the contract:


### PR DESCRIPTION
We're deploying Timelock v4.3.1 which patches the security bug. We did not reflect this in the documentation yet.