### PR TITLE
Update sentinel API with List response type

### DIFF
--- a/docs/modules/ROOT/pages/sentinel-api-reference.adoc
+++ b/docs/modules/ROOT/pages/sentinel-api-reference.adoc
@@ -118,7 +118,7 @@ An example response:
 [[list-endpoint]]
 === List Sentinels
 
-To list existing sentinels, you can call the `list` function on the client, which returns a `CreateSentinelResponse[]` object:
+To list existing sentinels, you can call the `list` function on the client, which returns a `ListSentinelResponse[]` object:
 
 ```js
 await client.list();

--- a/docs/modules/ROOT/pages/sentinel-api-reference.adoc
+++ b/docs/modules/ROOT/pages/sentinel-api-reference.adoc
@@ -118,7 +118,7 @@ An example response:
 [[list-endpoint]]
 === List Sentinels
 
-To list existing sentinels, you can call the `list` function on the client, which returns a `ListSentinelResponse[]` object:
+To list existing sentinels, you can call the `list` function on the client, which returns a `ListSentinelResponse` object:
 
 ```js
 await client.list();


### PR DESCRIPTION
Updates documentation to reflect this change: https://github.com/OpenZeppelin/defender-client/pull/66