### PR TITLE
update forta alert properties

### DIFF
--- a/docs/modules/ROOT/pages/sentinel.adoc
+++ b/docs/modules/ROOT/pages/sentinel.adoc
@@ -349,6 +349,8 @@ NOTE: Only alerts that match other conditions (Severity, Alert IDs) will invoke 
 
 The request body will contain the following structure. 
 
+NOTE: We have updated the Forta Alert schema in correspondence with the new https://docs.forta.network/en/latest/api/[Forta API]. The following changes were made: `alert_id` -> `alertId`, `scanner_count` -> `scanNodeCount`, `type` -> `findingType`, `tx_hash` -> `transactionHash`, `chain_Id` -> `chainId`, Agent `name` removed. Old properties are now deprecated but we will continue to send both to remain backwards compatible.
+
 [source,jsx]
 ----
 {
@@ -611,6 +613,9 @@ exports.handler = async function(params) {
 }
 ----
 ==== Forta Sentinel
+
+NOTE: We have updated the Forta Alert schema in correspondence with the new https://docs.forta.network/en/latest/api/[Forta API]. The following changes were made: `alert_id` -> `alertId`, `scanner_count` -> `scanNodeCount`, `type` -> `findingType`, `tx_hash` -> `transactionHash`, `chain_Id` -> `chainId`, Agent `name` removed. Old properties are now deprecated but we will continue to send both to remain backwards compatible.
+
 [source,jsx]
 ----
 {

--- a/docs/modules/ROOT/pages/sentinel.adoc
+++ b/docs/modules/ROOT/pages/sentinel.adoc
@@ -356,22 +356,21 @@ The request body will contain the following structure.
     {
       "alert": {                            // Forta Alert 
         "addresses": [ "0xab..123" ],       // map of addresses involved in the transaction
-        "alert_id": "NETHFORTA-1",          // unique string to identify this class of finding
+        "alertId": "NETHFORTA-1",           // unique string to identify this class of finding
         "name": "High Gas Used",            // human-readable name of finding
         "description": "Gas Used: 999999",  // brief description
         "hash": "0xab..123",                // Forta Alert transaction hash
         "protocol": "ethereum",             // specifies which network the transaction was mined
-        "scanner_count": 1,
+        "scanNodeCount": 1,
         "severity": "MEDIUM",               // indicates impact level of finding
-        "type": "SUSPICIOUS",               // indicates type of finding: Exploit, Suspicious, Degraded, Info
+        "findingType": "SUSPICIOUS",        // indicates type of finding: Exploit, Suspicious, Degraded, Info
         "source": {
-          "tx_hash": "0xab..123",           // network transaction hash  e.g ethereum transaction hash
+          "transactionHash": "0xab..123",   // network transaction hash  e.g ethereum transaction hash
           "agent": {
             "id": "0xab..123",              // Agent ID
-            "name": ""                      // Agent name
           },
           "block": {
-            "chain_id": 1,                  // Chain ID of the originating network       
+            "chainId": 1,                   // Chain ID of the originating network       
             "hash": "0xab..123",            // network block hash  e.g ethereum block hash   
           }
         }
@@ -617,22 +616,21 @@ exports.handler = async function(params) {
 {
   "alert": {                            // Forta Alert 
     "addresses": [ "0xab..123" ],       // map of addresses involved in the transaction
-    "alert_id": "NETHFORTA-1",          // unique string to identify this class of finding
+    "alertId": "NETHFORTA-1",           // unique string to identify this class of finding
     "name": "High Gas Used",            // human-readable name of finding
     "description": "Gas Used: 999999",  // brief description
     "hash": "0xab..123",                // Forta Alert transaction hash
     "protocol": "ethereum",             // specifies which network the transaction was mined
-    "scanner_count": 1,
+    "scanNodeCount": 1,
     "severity": "MEDIUM",               // indicates impact level of finding
-    "type": "SUSPICIOUS",               // indicates type of finding: Exploit, Suspicious, Degraded, Info
+    "findingType": "SUSPICIOUS",        // indicates type of finding: Exploit, Suspicious, Degraded, Info
     "source": {
-      "tx_hash": "0xab..123",           // network transaction hash  e.g ethereum transaction hash
+      "transactionHash": "0xab..123",   // network transaction hash  e.g ethereum transaction hash
       "agent": {
         "id": "0xab..123",              // Agent ID
-        "name": ""                      // Agent name
       },
       "block": {
-        "chain_id": 1,                  // Chain ID of the originating network       
+        "chainId": 1,                   // Chain ID of the originating network       
         "hash": "0xab..123",            // network block hash  e.g ethereum block hash  
       }
     }


### PR DESCRIPTION
Updates to the forta alert model in correspondence with the new API

`alert_id` -> `alertId`
`scanner_count` -> `scanNodeCount`
`type` -> `findingType`
`tx_hash` -> `transactionHash`
`chain_Id` -> `chainId`
Agent `name` removed