### PR TITLE
Added signTypedData

### DIFF
--- a/docs/modules/ROOT/pages/relay-api-reference.adoc
+++ b/docs/modules/ROOT/pages/relay-api-reference.adoc
@@ -171,7 +171,7 @@ An example of the response:
 
 [[sign-endpoint]]
 == Sign Endpoint
-To sign arbitrary data with your Relay private key make a `POST` request to `/sign` with a payload containing the hex string to sign. The payload format is:
+To sign arbitrary messages according to the https://eips.ethereum.org/EIPS/eip-191[EIP-191 Standard] (prefixed by `\x19Ethereum Signed Message:\n`) with your Relay private key make a `POST` request to `/sign` with a payload containing the hex string to sign. The payload format is:
 
 ```TypeScript
 interface SignMessagePayload {
@@ -192,6 +192,54 @@ curl \
   -H "Authorization: Bearer $TOKEN" \
   -d "$DATA" \
     "https://api.defender.openzeppelin.com/sign"
+```
+
+You would receive a response in the following format:
+
+```TypeScript
+interface SignedMessagePayload {
+  sig: Hex;
+  r: Hex;
+  s: Hex;
+  v: number;
+}
+```
+
+An example of the response:
+
+```JSON
+{
+   "r":"0x819b2645a0b73494724dac355e6ecfc983d94597b533d34fe3ecd0277046a1eb",
+   "s":"0x3b73c695b47dd275d17246d86bbfe35f112a7bdb5bf4a5a1a8e22fe37dfd005a",
+   "v":44,
+   "sig":"0x819b2645a0b73494724dac355e6ecfc983d94597b533d34fe3ecd0277046a1eb3b73c695b47dd275d17246d86bbfe35f112a7bdb5bf4a5a1a8e22fe37dfd005a2c"
+}
+```
+
+[[sign-typed-data-endpoint]]
+== Sign Typed Data Endpoint
+To sign typed data according to the [EIP-712 Specification](https://eips.ethereum.org/EIPS/eip-712) with your Relay private key make a `POST` request to `/sign` with a payload containing the `domainSeparator` and the `hashStruct(message)`. Both should be 32-bytes long as they're hashes theirselves. The payload format is:
+
+```TypeScript
+interface SignTypedDataPayload {
+  domainSeparator: Hex;
+  hashStructMessage: Hex;
+}
+```
+
+An example of the request:
+
+```bash
+DATA='{ "domainSeparator": "0x0123456789abcdef...", "hashStructMessage": "0x0123456789abcdef..." }'
+
+curl \
+  -X POST \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H "X-Api-Key: $KEY" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "$DATA" \
+    "https://api.defender.openzeppelin.com/sign-typed-data"
 ```
 
 You would receive a response in the following format:

--- a/docs/modules/ROOT/pages/relay.adoc
+++ b/docs/modules/ROOT/pages/relay.adoc
@@ -224,11 +224,25 @@ const txs = await relayer.list({
 [[signing]]
 == Signing
 
-In addition to sending transactions, the Relayer can also sign arbitrary messages using its private key. You can access this feature via the `sign` method of the client or the equivalent ethers.js method.
+In addition to sending transactions, the Relayer can also sign arbitrary messages according to the https://eips.ethereum.org/EIPS/eip-191[EIP-191 Standard] (prefixed by `\x19Ethereum Signed Message:\n`) using its private key. You can access this feature via the `sign` method of the client or the equivalent ethers.js method.
 
 [source,jsx]
 ----
 const signResponse = await relayer.sign({ message });
+----
+
+[[signing-typed-data]]
+== Signing Typed Data
+
+Along with the sign api method, the Relayer also implements a `signTypedData`, which you can use to sign messages according to the https://eips.ethereum.org/EIPS/eip-712[EIP712 Standard] for typed data signatures.
+You can either provide the `domainSeparator` and `hashStruct(message)` or use the equivalent ethers.js method
+
+[source,jsx]
+----
+const signTypedDataResponse = await relayer.signTypedData({
+  domainSeparator,
+  hashStructMessage
+});
 ----
 
 [[relayer-info]]


### PR DESCRIPTION
## Changes

- Added `signTypedData` endpoint docs
- Updated previous `sign` endpoint docs as it didn't sign arbitrary data but `\x19Ethereum Signed Message:\n` prefixed data