### PR TITLE
correct sentinel and relayer api endpoints (#121)

### DIFF
--- a/docs/modules/ROOT/pages/relay-api-reference.adoc
+++ b/docs/modules/ROOT/pages/relay-api-reference.adoc
@@ -45,7 +45,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/relayers/summary"
+    "https://defender-api.openzeppelin.com/relayer/relayers/summary"
 ```
 
 An example response:
@@ -84,7 +84,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/relayers/58b3d255-e357-4b0d-aa16-e86f745e63b9/keys"
+    "https://defender-api.openzeppelin.com/relayer/relayers/58b3d255-e357-4b0d-aa16-e86f745e63b9/keys"
 ```
 
 An example response:
@@ -160,7 +160,7 @@ curl \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{...}' \
-    "https://defender-api.openzeppelin.com/relayers"
+    "https://defender-api.openzeppelin.com/relayer/relayers"
 ```
 
 [[relayer-policies]]
@@ -190,7 +190,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/relayers/58b3d255-e357-4b0d-aa16-e86f745e63b9/keys"
+    "https://defender-api.openzeppelin.com/relayer/relayers/58b3d255-e357-4b0d-aa16-e86f745e63b9/keys"
 ```
 
 An example response:
@@ -236,7 +236,7 @@ curl \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{...}' \
-    "https://defender-api.openzeppelin.com/relayers"
+    "https://defender-api.openzeppelin.com/relayer/relayers"
 ```
 
 NOTE: If making the request directly (not with `defender-relay-client`), any policy updates will need to be made via requests to the endpoint directly below with a body type of `UpdateRelayerPoliciesRequest`.
@@ -249,7 +249,7 @@ curl \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{...}' \
-    "https://defender-api.openzeppelin.com/relayers/{relayerId}"
+    "https://defender-api.openzeppelin.com/relayer/relayers/{relayerId}"
 ```
 
 [[delete-key-endpoint]]
@@ -273,7 +273,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/relayers/58b3d255-e357-4b0d-aa16-e86f745e63b9/keys/j3bru93-k32l-3p1s-pp56-u43f675e92p1"
+    "https://defender-api.openzeppelin.com/relayer/relayers/58b3d255-e357-4b0d-aa16-e86f745e63b9/keys/j3bru93-k32l-3p1s-pp56-u43f675e92p1"
 ```
 
 An example response:

--- a/docs/modules/ROOT/pages/sentinel-api-reference.adoc
+++ b/docs/modules/ROOT/pages/sentinel-api-reference.adoc
@@ -89,7 +89,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/notifications"
+    "https://defender-api.openzeppelin.com/sentinel/notifications"
 ```
 
 An example response:
@@ -133,7 +133,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/subscribers"
+    "https://defender-api.openzeppelin.com/sentinel/subscribers"
 ```
 
 An example response:
@@ -382,7 +382,7 @@ curl \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{...}' \
-    "https://defender-api.openzeppelin.com/subscribers"
+    "https://defender-api.openzeppelin.com/sentinel/subscribers"
 ```
 
 [[retrieve-endpoint]]
@@ -402,7 +402,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/subscribers/{id}"
+    "https://defender-api.openzeppelin.com/sentinel/subscribers/{id}"
 ```
 
 [[update-endpoint]]
@@ -426,7 +426,7 @@ curl \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{...}' \
-    "https://defender-api.openzeppelin.com/subscribers/{id}"
+    "https://defender-api.openzeppelin.com/sentinel/subscribers/{id}"
 ```
 
 [[delete-endpoint]]
@@ -447,7 +447,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H "X-Api-Key: $KEY" \
   -H "Authorization: Bearer $TOKEN" \
-    "https://defender-api.openzeppelin.com/subscribers/{id}"
+    "https://defender-api.openzeppelin.com/sentinel/subscribers/{id}"
 ```
 
 An example response:


### PR DESCRIPTION
The URLs for direct calls didn't have the required custom mapping prefix (the client packages work fine though).

See: https://github.com/OpenZeppelin/defender-docs/issues/121