### PR TITLE
Added note for Receiver Whitelist in internal transfers

### DIFF
--- a/docs/modules/ROOT/pages/relay.adoc
+++ b/docs/modules/ROOT/pages/relay.adoc
@@ -62,6 +62,8 @@ NOTE: In addition to the maximum gas price policy you can specify here, Defender
 
 NOTE: EIP1559 Pricing policy is enabled by default for new relayers. If you have a Relayer that was created without the default opt-in, you can always enable this flag.
 
+NOTE: The receiver whitelist applies only to the `to` field of a transaction. It doesn't filter ERC20 or other assets receivers.
+
 [[sending-transactions]]
 == Sending transactions
 


### PR DESCRIPTION
In response to a [forum issue](https://forum.openzeppelin.com/t/clarification-on-defender-relayer-whitelist/30917/3), we're adding a note specifying a restriction around the `Whitelist Receivers` policy, since it doesn't apply to functions like `transfer` or `transferFrom`, where the receiver is encoded in the calldata