### PR TITLE
Add a required type attribute for creating new Sentinels

### DIFF
--- a/docs/modules/ROOT/pages/sentinel-api-reference.adoc
+++ b/docs/modules/ROOT/pages/sentinel-api-reference.adoc
@@ -273,6 +273,7 @@ The alert threshold is set to 2 times within 1 hour, and the user will be notifi
 
 ```js
 const requestParameters = {
+  type: 'BLOCK',
   network: 'rinkeby',
   // optional
   confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset


### PR DESCRIPTION
Add the required type attribute for `requestParameters`.