### PR TITLE
correct Autotask local development dependencies requirements

### DIFF
--- a/docs/modules/ROOT/pages/autotasks.adoc
+++ b/docs/modules/ROOT/pages/autotasks.adoc
@@ -310,9 +310,12 @@ NOTE: If you need to use any dependency not listed above, you can either use a j
 [[local-development]]
 === Local development
 
-To reproduce exactly the same Autotask environment in your development setup, you can use the following lockfile to install the same set of dependencies via `yarn install --frozen-lockfile`.
+To reproduce exactly the same Autotask environment in your development setup:
 
-📎 link:{attachmentsdir}/yarn.lock[yarn.lock]
+* Initialize a new npm project (`npm init`)
+* Set the `dependencies` key in `package.json` to the packages indicated in the <<#environment,Environment>> section above
+* Download `yarn.lock`: 📎 link:{attachmentsdir}/yarn.lock[yarn.lock]
+* Run `yarn install --frozen-lockfile`.
 
 You can also use the following template for local development, which will run your Autotask code when invoked locally using `node`. It will load the Relayer credentials from environment variables when run locally, or use the injected credentials when run in Defender.
 


### PR DESCRIPTION
This section didn't work to set up local dev previously. This seems to work now.

One thing that came to mind @zeljkoX (or others)  - what do you think about exposing the most recent `yarn.lock` in the UI along with those dependencies so we don't need to maintain a yarn.lock in this repo?