### PR TITLE
docs: note on event and internal calls support

### DIFF
--- a/docs/modules/ROOT/pages/sentinel.adoc
+++ b/docs/modules/ROOT/pages/sentinel.adoc
@@ -67,9 +67,7 @@ NOTE: An ABI is required to configure Events and Function detection
 
 NOTE: If no Events or Functions are specified, then the Sentinel will monitor ALL transactions to or from your monitored addresses.
 
-NOTE: Sentinels seamlessly supports notifications for events emitted by a smart contract on all networks, regardless of whether they are triggered directly or through internal calls from a third contract. However, the capability to track and provide notifications specifically for internal function calls within a contract is currently limited to the Ethereum mainnet.
-
-IMPORTANT: At this time, Sentinels can only monitor internal function calls on Mainnet, Ropsten, and Kovan.  If the internal call emits an event, consider monitoring for that event instead.  Events emitted from internal calls are detected on all networks.
+IMPORTANT: Sentinels seamlessly supports notifications for events emitted by a smart contract on all networks, regardless of whether they are triggered directly or through internal calls from a third contract. However, the capability to track and provide notifications specifically for internal function calls within a contract is currently limited to the Ethereum mainnet.
 
 [[hedera-support]]
 === Hedera Support

--- a/docs/modules/ROOT/pages/sentinel.adoc
+++ b/docs/modules/ROOT/pages/sentinel.adoc
@@ -67,6 +67,8 @@ NOTE: An ABI is required to configure Events and Function detection
 
 NOTE: If no Events or Functions are specified, then the Sentinel will monitor ALL transactions to or from your monitored addresses.
 
+NOTE: Sentinels seamlessly supports notifications for events emitted by a smart contract on all networks, regardless of whether they are triggered directly or through internal calls from a third contract. However, the capability to track and provide notifications specifically for internal function calls within a contract is currently limited to the Ethereum mainnet.
+
 IMPORTANT: At this time, Sentinels can only monitor internal function calls on Mainnet, Ropsten, and Kovan.  If the internal call emits an event, consider monitoring for that event instead.  Events emitted from internal calls are detected on all networks.
 
 [[hedera-support]]


### PR DESCRIPTION
Add note about the support of Events and internal calls by Sentinels.