### PR TITLE
Mark v2 as beta

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,6 @@
 name: defender
 title: Defender
 version: v2
+prerelease: -beta
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
If we do this, and we remove the [rule](https://github.com/OpenZeppelin/docs.openzeppelin.com/blob/9c460bbfcb3cba7fc19cb09c83f943c914d7551e/playbook.yml#L65) that excludes `docs-v2`, v2 will be included in the normal docs site but it will not be considered latest, so v1 will continue being the default.