### PR TITLE
Improve sdk examples

### DIFF
--- a/docs/modules/ROOT/pages/manage/relayers.adoc
+++ b/docs/modules/ROOT/pages/manage/relayers.adoc
@@ -86,14 +86,17 @@ NOTE: Private transactions are only enabled for _goerli_ and _mainnet_ by using 
 [[sending-transactions]]
 == Sending transactions
 
-The easiest way to send a transaction via a Relayer is using the https://www.npmjs.com/package/@openzeppelin/defender-sdk-relay-client[`Defender 2.0 SDK Relay Client`, window=_blank] package. The client is initialized with an API key/secret and exposes a simple API for sending transactions through the corresponding Relayer.
+The easiest way to send a transaction via a Relayer is using the https://www.npmjs.com/package/@openzeppelin/defender-sdk[`Defender 2.0 SDK`, window=_blank] package. The client is initialized with an API key/secret and exposes a simple API for sending transactions through the corresponding Relayer.
 
 [source,jsx]
 ----
-import { Relayer } from 'defender-relay-client';
-const relayer = new Relayer({apiKey: YOUR_API_KEY, apiSecret: YOUR_API_SECRET});
+const { Defender } = require('@openzeppelin/defender-sdk');
+const client = new Defender({
+  relayerApiKey: 'YOUR_API_KEY',
+  relayerApiSecret: 'YOUR_API_SECRET'
+});
 
-const tx = await relayer.sendTransaction({
+const tx = await client.relayerSigner.sendTransaction({
   to, value, data, gasLimit, speed: 'fast'
 });
 ----
@@ -109,19 +112,21 @@ The Relayer client integrates with https://docs.ethers.io/v6/[ethers.js, window=
 
 [source,jsx]
 ----
-const { DefenderRelaySigner, DefenderRelayProvider } = require('defender-relay-client/lib/ethers');
+const { Defender } = require('@openzeppelin/defender-sdk');
 const { ethers } = require('ethers');
  
-const credentials = { apiKey: YOUR_API_KEY, apiSecret: YOUR_API_SECRET };
-const provider = new DefenderRelayProvider(credentials);
-const signer = new DefenderRelaySigner(credentials, provider, { speed: 'fast' });
+const credentials = { relayerApiKey: YOUR_RELAYER_API_KEY, relayerApiSecret: YOUR_RELAYER_API_SECRET };
+const client = new Defender(credentials);
+
+const provider = client.relaySigner.getProvider();
+const signer = client.relaySigner.getSigner(provider, { speed: 'fast', validUntil });
 
 const erc20 = new ethers.Contract(ERC20_ADDRESS, ERC20_ABI, signer);
 const tx = await erc20.transfer(beneficiary, 1e18.toString());
 const mined = await tx.wait();
 ----
 
-In the example above, we are also using a `DefenderRelayProvider` for making calls to the network. The Platfro signer can work with any provider, such as `ethers.getDefaultProvider()`, but you can rely on Defender 2.0 as a network provider as well. 
+In the example above, we are also using a `DefenderRelayProvider` for making calls to the network. The signer can work with any provider, such as `ethers.getDefaultProvider()`, but you can rely on Defender 2.0 as a network provider as well. 
 
 You can read more about the ethers integration https://www.npmjs.com/package/@openzeppelin/defender-sdk-relay-client[here, window=_blank].
 
@@ -132,11 +137,14 @@ The Relayer client integrates with https://web3js.readthedocs.io/[web3.js, windo
 
 [source,jsx]
 ----
-const { DefenderRelayProvider } = require('defender-relay-client/lib/web3');
+const { Defender } = require('@openzeppelin/defender-sdk');
 const Web3 = require('web3');
+
+const credentials = { relayerApiKey: YOUR_RELAYER_API_KEY, relayerApiSecret: YOUR_RELAYER_API_SECRET };
+const client = new Defender(credentials);
+
+const provider = client.relaySigner.getProvider();
  
-const credentials = { apiKey: YOUR_API_KEY, apiSecret: YOUR_API_SECRET };
-const provider = new DefenderRelayProvider(credentials, { speed: 'fast' });
 const web3 = new Web3(provider);
 
 const [from] = await web3.eth.getAccounts();

--- a/docs/modules/ROOT/pages/module/actions.adoc
+++ b/docs/modules/ROOT/pages/module/actions.adoc
@@ -338,12 +338,13 @@ You can also use the following template for local development, which will run th
 
 [source,jsx]
 ----
-const { Relayer } = require('defender-relay-client');
+const { Defender } = require('@openzeppelin/defender-sdk');
+
 
 // Entrypoint for the action
 exports.handler = async function(event) {
-  const relayer = new Relayer(event);
-  // Use relayer for sending txs
+  const client = new Defender(credentials);
+  // Use client.relaySigner for sending txs
 }
 
 // To run locally (this code will not be executed in actions)
@@ -358,13 +359,7 @@ if (require.main === module) {
 [[updating-code]]
 === Updating code
 
-You can edit an action's code via the Defender 2.0 interface, or programmatically via API using the https://www.npmjs.com/package/defender-autotask-client[`defender-autotask-client`, window=_blank] npm package. The latter allows to upload a code bundle with more than a single file:
-
-```bash
-$ echo API_KEY=$API_KEY >> .env
-$ echo API_SECRET=$API_SECRET >> .env
-$ defender-autotask update-code $AUTOTASK_ID ./path/to/code
-```
+You can edit an action's code via the Defender 2.0 interface, or programmatically via API using the https://www.npmjs.com/package/@openzeppelin/defender-sdk[`defender-sdk`, window=_blank] npm package. The latter allows to upload a code bundle with more than a single file:
 
 NOTE: The code bundle must not exceed 5MB in size after being compressed and base64-encoded, and it must always include an `index.js` at the root of the zip file to act as the entrypoint.
 

--- a/docs/modules/ROOT/pages/module/deploy.adoc
+++ b/docs/modules/ROOT/pages/module/deploy.adoc
@@ -74,7 +74,7 @@ The history table shows the activity within the environment, allowing you to che
 [[deployments]]
 == Deploying and Upgrading
 
-After an environment is configured, you can use it for deployments and upgrades. To do so, we provide an https://www.npmjs.com/package/defender-sdk-deploy-client[API, window=_blank] and a https://www.npmjs.com/package/@openzeppelin/hardhat-upgrades[Hardhat plugin, window=_blank]. The Deploy API is recommended for non-Hardhat projects. On the other hand, the Hardhat plugin is extremely easy to use in Hardhat projects, as it only requires a few lines of code to implement.
+After an environment is configured, you can use it for deployments and upgrades. To do so, we provide an https://www.npmjs.com/package/@openzeppelin/defender-sdk-deploy-client[API, window=_blank] and a https://www.npmjs.com/package/@openzeppelin/hardhat-upgrades[Hardhat plugin, window=_blank]. The Deploy API is recommended for non-Hardhat projects. On the other hand, the Hardhat plugin is extremely easy to use in Hardhat projects, as it only requires a few lines of code to implement.
 
 Both the API and the Hardhat plugin allow using different relayers for each contract deployment. However, if none is specified, Defender 2.0 will identify the target network and use the associated default relayer. If the environment is configured with the block explorer API key, Defender 2.0 will also automatically verify the contracts.
 


### PR DESCRIPTION
Use defender-sdk  instead of Defender 1.0 packages for examples in docs.