### PR TITLE
Remove relayer quota from docs

### DIFF
--- a/docs/modules/ROOT/pages/manage/relayers.adoc
+++ b/docs/modules/ROOT/pages/manage/relayers.adoc
@@ -411,7 +411,6 @@ Every minute, all in-flight transactions are checked by the system. If they have
 
 Relayers assign nonces atomically which allows them to handle many concurrent transactions. However, there do exist limits to optimize the infrastructure (all numbers below are cumulative of all Relayers in an account):
 
-* 120 transactions/hour (free tier only)
 * 100 total requests/second
 * 10 transactions/second
 


### PR DESCRIPTION
Removes relayer quota from docs.
https://openzeppelin.slack.com/archives/C04T00M1DNW/p1694000596672749?thread_ts=1693974304.603779&cid=C04T00M1DNW

@zanbel