### PR TITLE
improve instructions to run actions locally

### DIFF
--- a/docs/modules/ROOT/pages/module/actions.adoc
+++ b/docs/modules/ROOT/pages/module/actions.adoc
@@ -349,12 +349,14 @@ exports.handler = async function(event) {
 
 // To run locally (this code will not be executed in actions)
 if (require.main === module) {
-  const { API_KEY: apiKey, API_SECRET: apiSecret } = process.env;
+  const { RELAYER_API_KEY: apiKey, RELAYER_API_SECRET: apiSecret } = process.env;
   exports.handler({ apiKey, apiSecret })
     .then(() => process.exit(0))
     .catch(error => { console.error(error); process.exit(1); });
 }
 ----
+
+Remember to send any other value that your action expects in the `event` object, such as secrets or monitor events.
 
 [[updating-code]]
 === Updating code


### PR DESCRIPTION
Following feedback that it wasn't clear that the expected API key to run actions locally was the Relayer API Key and not the Team API key I'm making the example clearer. 