### PR TITLE
Add docs sections for relayer status method

### DIFF
--- a/docs/modules/ROOT/pages/manage/relayers.adoc
+++ b/docs/modules/ROOT/pages/manage/relayers.adoc
@@ -370,6 +370,39 @@ export interface RelayerModel {
 }
 ----
 
+[[relayer-status]]
+== Relayer Status
+
+To gain better insight into the current status of a relayer, one can use the `getRelayerStatus` method from the `DefenderRelaySigner` class. This method provides real-time information about a relayer, such as its nonce, transaction quota, and the number of pending transactions.
+[source,jsx]
+----
+const address = await signer.getRelayerStatus();
+----
+
+If you need info about a Relayer then checkout the `getRelayer` method of the client. It returns the following data:
+
+[source,jsx]
+----
+export interface RelayerStatus {
+  relayerId: string;
+  name: string;
+  nonce: number;
+  address: string;
+  numberOfPendingTransactions: number;
+  paused: boolean;
+  pendingTxCost?: string;
+  txsQuotaUsage: number;
+  rpcQuotaUsage: number;
+  lastConfirmedTransaction?: {
+    hash: string;
+    status: string;
+    minedAt: string;
+    sentAt: string;
+    nonce: number;
+  };
+}
+----
+
 [[network-calls]]
 == Network calls
 

--- a/docs/modules/ROOT/pages/module/actions.adoc
+++ b/docs/modules/ROOT/pages/module/actions.adoc
@@ -132,7 +132,7 @@ exports.handler = async function(event) {
 Actions triggered from a Monitor can have two types of body properties and scheme, depending what type of Monitor triggered the action:
 
 * In the case of a Defender 2.0 monitor, the body will contain the xref:module/monitor.adoc#monitor_event_schema[monitor event schema].
-* In the case of a Forta monitor, the body will contain the xref:guide/forta-monitor.adoc[Forta Alert details].
+* In the case of a Forta monitor, the body will contain the Forta Alert details.
 
 If the action is written in TypeScript, `BlockTriggerEvent` or `FortaTriggerEvent` types from the https://www.npmjs.com/package/@openzeppelin/defender-sdk-action-client[defender-sdk-action-client, window=_blank] package can be used.
 


### PR DESCRIPTION
This PR will add documentation for relayer status client method.

Note: should be merged once client package gets published.

Also, broken link to Forta usage guide is removed.

<img width="798" alt="Screenshot 2023-10-06 at 09 54 28" src="https://github.com/OpenZeppelin/defender-docs/assets/2046481/7bfd551d-7670-4dbd-80f9-f69fa5a90f9e">
