### PR TITLE
Use getUpgradeApprovalProcess in deploy tutorial

### DIFF
--- a/docs/modules/ROOT/pages/tutorial/deploy.adoc
+++ b/docs/modules/ROOT/pages/tutorial/deploy.adoc
@@ -186,13 +186,13 @@ import { ethers, defender } from "hardhat";
 async function main() {
   const Box = await ethers.getContractFactory("Box");
 
-  const defaultApprovalProcess = await defender.getDefaultApprovalProcess();
+  const upgradeApprovalProcess = await defender.getUpgradeApprovalProcess();
 
-  if (defaultApprovalProcess.address === undefined) {
-    throw new Error(`Upgrade approval process with id ${defaultApprovalProcess.approvalProcessId} has no assigned address`);
+  if (upgradeApprovalProcess.address === undefined) {
+    throw new Error(`Upgrade approval process with id ${upgradeApprovalProcess.approvalProcessId} has no assigned address`);
   }
 
-  const deployment = await defender.deployProxy(Box, [5, defaultApprovalProcess.address], { initializer: "initialize" });
+  const deployment = await defender.deployProxy(Box, [5, upgradeApprovalProcess.address], { initializer: "initialize" });
 
   await deployment.waitForDeployment();
 


### PR DESCRIPTION
Change `getDefaultApprovalProcess` to `getUpgradeApprovalProcess`.

`getDefaultApprovalProcess` is deprecated as of [@openzeppelin/hardhat-upgrades@2.5.0](https://github.com/OpenZeppelin/openzeppelin-upgrades/releases/tag/%40openzeppelin%2Fhardhat-upgrades%402.5.0)