### PR TITLE
Remove notification category references

### DIFF
--- a/docs/modules/ROOT/pages/dac.adoc
+++ b/docs/modules/ROOT/pages/dac.adoc
@@ -101,9 +101,7 @@ A list of properties that support direct referencing:
 - `action-trigger` may reference an `actionid` in Monitor
 - `action-condition` may reference an `actionId` in Monitor
 - `address-from-relayer` may reference a `relayerId` in Relayer
-- `notification-ids` may reference multiple `notificationId` in Category
 - `notify-config.channels` may reference multiple `notificationId` in Monitor
-- `notify-config.category` may reference a `categoryId` in Monitor
 - `contracts` may be used over `addresses` and reference multiple `contractId` in Monitor
   The following is an example of how a direct reference to a Defender contract and relayer can be used in monitor and action respectively:
 
@@ -206,14 +204,6 @@ You can use `sls invoke --function <stack_resource_id>` to manually run an actio
 NOTE: Each command has a standard output to a JSON object.
 
 == Caveats
-
-Note that when setting up the notification configuration for a monitor, the `channels` property will always be prioritised over `category`. A notification category can only be associated to a monitor with no linked notification channels. This means that the `channels` property should be assigned the value `[]` in order to prioritise the `category` property.
-
-```yaml
-notify-config:
-  channels: [] # assign channels as empty list if you wish to use a category
-  category: ${self:resources.categories.medium-severity} # optional
-```
 
 Errors thrown during the `deploy` process, will not revert any prior changes. Common errors are:
 

--- a/docs/modules/ROOT/pages/module/monitor.adoc
+++ b/docs/modules/ROOT/pages/module/monitor.adoc
@@ -278,7 +278,7 @@ $1 == "hello"
 [[alerts]]
 == Alerts
 
-A monitor can use any supported notification channel for alerting. It's also possible to connect an Action or an Workflow that should run with the monitor.
+A monitor can use any supported notification channel for alerting. It's also possible to connect an Action or a Workflow that should run with the monitor.
 
 To prevent repeated alerts from individual monitors and control the notification rate, you can use the Alert Threshold and Minimum time between consecutive notifications fields.
 

--- a/docs/modules/ROOT/pages/module/monitor.adoc
+++ b/docs/modules/ROOT/pages/module/monitor.adoc
@@ -27,13 +27,11 @@ Monitors are organized into five categories, according to the type of risk they 
 * Financial
 * Technical
 
-You can also specify a severity for each alert, which your team can use to prioritize notifications. Each severity can then be associated with one or more notification channels.
+You can also specify a severity level, which your team can use to group or filter monitors by.
 
 * High Severity
 * Medium Severity
 * Low Severity
-
-Severities and notification channels should be combined according to the project. For example, a DeFi protocol may prefer financial monitors with a high-priority channel, such as Slack/Telegram, and technical monitors with a lower-priority channel, such as email.
 
 [[configure-a-monitor]]
 == Configuring a Monitor
@@ -280,7 +278,7 @@ $1 == "hello"
 [[alerts]]
 == Alerts
 
-A monitor can either use the notification channel of its category or a custom one. It's also possible to connect an Action or an Workflow that should run with the monitor.
+A monitor can use any supported notification channel for alerting. It's also possible to connect an Action or an Workflow that should run with the monitor.
 
 To prevent repeated alerts from individual monitors and control the notification rate, you can use the Alert Threshold and Minimum time between consecutive notifications fields.
 

--- a/docs/modules/ROOT/pages/tutorial/monitor.adoc
+++ b/docs/modules/ROOT/pages/tutorial/monitor.adoc
@@ -45,7 +45,7 @@ image::tutorial-monitor-transaction-filters.png[Monitor transaction filters]
 image::tutorial-monitor-event-filter.png[Monitor event filter]
 
 . Skip function-level filters as you are already tracking all `Swap` events emitted from the contract. 
-. Select the `High Severity` notification category, tied to a channel of your choice (such as email).
+. Select a notification channel of your choice (such as email).
 . Click on *Save Monitor*.
 
 +


### PR DESCRIPTION
https://linear.app/openzeppelin-development/issue/PLAT-4418/remove-notification-category-references-from-docs