### PR TITLE
docs(relayers.adoc): Improves relayer send transaction code example

### DIFF
--- a/docs/modules/ROOT/pages/manage/relayers.adoc
+++ b/docs/modules/ROOT/pages/manage/relayers.adoc
@@ -109,6 +109,8 @@ const client = new Defender({
 const tx = await client.relayerSigner.sendTransaction({
   to, value, data, gasLimit, speed: 'fast'
 });
+
+const mined = await tx.wait();
 ----
 
 [CAUTION]


### PR DESCRIPTION
This change makes usage more clear by informing users that they must call the `wait()` method on the returned ethers `TransactionResponse` object. 