### PR TITLE
Update autotask dependencies

### DIFF
--- a/docs/modules/ROOT/pages/admin-api-reference.adoc
+++ b/docs/modules/ROOT/pages/admin-api-reference.adoc
@@ -5,9 +5,9 @@ The Admin API allows you to programmatically create new Admin proposals.
 
 Requests need to be authenticated with a bearer token, which is negotiated from the Team API Key with the corresponding capability. Refer to the xref:api-auth.adoc[authentication section] for info on how to negotiate it.
 
-NOTE: We recommend you use the https://www.npmjs.com/package/defender-admin-client[defender-admin-client] npm package for simplifying interactions with the Admin API.
+NOTE: We recommend you use the https://www.npmjs.com/package/@openzeppelin/defender-admin-client[@openzeppelin/defender-admin-client] npm package for simplifying interactions with the Admin API.
 
-NOTE: It is not recommended to use the https://www.npmjs.com/package/defender-admin-client[defender-admin-client] npm package in a browser environment as sensitive keys would be exposed publicly.
+NOTE: It is not recommended to use the https://www.npmjs.com/package/@openzeppelin/defender-admin-client[@openzeppelin/defender-admin-client] npm package in a browser environment as sensitive keys would be exposed publicly.
 
 [[proposals-endpoint]]
 == Proposals Endpoint
@@ -150,7 +150,7 @@ curl \
     "https://defender-api.openzeppelin.com/admin/contracts/${CONTRACT_ID}/proposals/${PROPOSAL_ID}/archived"
 ```
 
-The same call can be made using `defender-admin-client`:
+The same call can be made using `@openzeppelin/defender-admin-client`:
 
 ```js
 await client.archiveProposal(contractId, proposalId);
@@ -173,7 +173,7 @@ curl \
     "https://defender-api.openzeppelin.com/admin/contracts/${CONTRACT_ID}/proposals/${PROPOSAL_ID}"
 ```
 
-The same call can be made using `defender-admin-client` passing the contract and proposal IDs:
+The same call can be made using `@openzeppelin/defender-admin-client` passing the contract and proposal IDs:
 
 ```js
 await client.getProposal(contractId, proposalId);

--- a/docs/modules/ROOT/pages/admin.adoc
+++ b/docs/modules/ROOT/pages/admin.adoc
@@ -37,7 +37,7 @@ video::XJ3UUNYlbxg[youtube]
 [[api-access]]
 == API Access
 
-You can programmatically add contracts to your Admin dashboard and create new proposals via the xref:admin-api-reference.adoc[Defender Admin API]. Check out the https://www.npmjs.com/package/defender-admin-client[defender-admin-client] npm package for more info.
+You can programmatically add contracts to your Admin dashboard and create new proposals via the xref:admin-api-reference.adoc[Defender Admin API]. Check out the https://www.npmjs.com/package/@openzeppelin/defender-admin-client[@openzeppelin/defender-admin-client] npm package for more info.
 
 [[proposal-types]]
 == Proposal types
@@ -120,7 +120,7 @@ When using a Gnosis Safe, Defender Admin will synchronize all signatures to and 
 
 NOTE: The Safe contract requires all its proposals to be executed in order. If you have gathered all signatures for a proposal and still cannot execute it, make sure there are no prior proposals pending execution.
 
-Gnosis Safe wallets also allow executing `DELEGATECALL`s into other contracts, in order to execute arbitrary code in the context of the multisig. You can currently create an Admin action proposal to issue a delegate call via the API using the https://www.npmjs.com/package/defender-admin-client[`defender-admin-client`]. 
+Gnosis Safe wallets also allow executing `DELEGATECALL`s into other contracts, in order to execute arbitrary code in the context of the multisig. You can currently create an Admin action proposal to issue a delegate call via the API using the https://www.npmjs.com/package/@openzeppelin/defender-admin-client[`@openzeppelin/defender-admin-client`]. 
 
 [[send-funds]]
 ==== Send funds
@@ -353,7 +353,7 @@ See below an example of an exact match.
 
 image::defender-admin-verification-exact.png[Exact verification]
 
-To verify programmatically, we strongly recommend using the https://www.npmjs.com/package/@openzeppelin/hardhat-defender#verification[hardhat-defender plugin]. However, you may also use https://www.npmjs.com/package/defender-admin-client[defender-client package] (https://github.com/OpenZeppelin/defender-client/tree/master/examples/verify-contract[see a verification example here]), or interact with the raw REST API directly. These components build upon each other, so at the end of the day all capabilities are available through any of them. We still recommend you use the `hardhat-defender` plugin for the most streamlined experience.
+To verify programmatically, we strongly recommend using the https://www.npmjs.com/package/@openzeppelin/hardhat-defender#verification[hardhat-defender plugin]. However, you may also use https://www.npmjs.com/package/@openzeppelin/defender-admin-client[defender-client package] (https://github.com/OpenZeppelin/defender-client/tree/master/examples/verify-contract[see a verification example here]), or interact with the raw REST API directly. These components build upon each other, so at the end of the day all capabilities are available through any of them. We still recommend you use the `hardhat-defender` plugin for the most streamlined experience.
 
 === Verifying any contract
 
@@ -363,7 +363,7 @@ The UI for verification in this case can be found by hovering any contract addre
 
 image::defender-admin-verification-any.png[Verification of any contract]
 
-Similarly, you can also trigger programmatical verification of any contract using the `defender-admin-client` client library or the `@openzeppelin/hardhat-defender` plugin for Hardhat. It is not necessary for the verified contract to take part in an upgrade.
+Similarly, you can also trigger programmatical verification of any contract using the `@openzeppelin/defender-admin-client` client library or the `@openzeppelin/hardhat-defender` plugin for Hardhat. It is not necessary for the verified contract to take part in an upgrade.
 
 [[security-considerations]]
 == Security considerations

--- a/docs/modules/ROOT/pages/autotasks-api-reference.adoc
+++ b/docs/modules/ROOT/pages/autotasks-api-reference.adoc
@@ -5,9 +5,9 @@ The Autotask API allows you to programmatically list, create, retrieve, update, 
 
 Requests need to be authenticated with a bearer token, which is negotiated from the Team API Key with the corresponding capability. Refer to the xref:api-auth.adoc[authentication section] for info on how to negotiate it.
 
-NOTE: We recommend you use the https://www.npmjs.com/package/defender-autotask-client[defender-autotask-client] npm package for simplifying interactions with the Autotask API.
+NOTE: We recommend you use the https://www.npmjs.com/package/@openzeppelin/defender-autotask-client[@openzeppelin/defender-autotask-client] npm package for simplifying interactions with the Autotask API.
 
-NOTE: It is not recommended to use the https://www.npmjs.com/package/defender-autotask-client[defender-autotask-client] npm package in a browser environment as sensitive keys would be exposed publicly.
+NOTE: It is not recommended to use the https://www.npmjs.com/package/@openzeppelin/defender-autotask-client[@openzeppelin/defender-autotask-client] npm package in a browser environment as sensitive keys would be exposed publicly.
 
 [[create-endpoint]]
 == Create Endpoint
@@ -28,7 +28,7 @@ interface CreateAutotaskRequest {
 }
 ```
 
-Using the `defender-autotask-client`, you can call the `create` endpoint as such:
+Using the `@openzeppelin/defender-autotask-client`, you can call the `create` endpoint as such:
 
 ```js
 const myAutotask = {
@@ -48,7 +48,7 @@ await client.create(myAutotask);
 
 The `autotasks` endpoint is used for retrieving an Autotask via a `GET` request.
 
-Using the `defender-autotask-client`, you can call the `list` endpoint as such:
+Using the `@openzeppelin/defender-autotask-client`, you can call the `list` endpoint as such:
 
 ```js
 await client.list();
@@ -83,7 +83,7 @@ An example response:
 
 The `autotasks/{id}` endpoint is used for retrieving an Autotask via a `GET` request. The endpoint accepts an autotask Id.
 
-Using the `defender-autotask-client`, you can call the `get` endpoint as such:
+Using the `@openzeppelin/defender-autotask-client`, you can call the `get` endpoint as such:
 
 ```js
 await client.get("671d1f80-99e3-4829-aa15-f01e3298e428");
@@ -121,7 +121,7 @@ interface UpdateAutotaskRequest {
 }
 ```
 
-Using the `defender-autotask-client`, you can call the `update` endpoint as such:
+Using the `@openzeppelin/defender-autotask-client`, you can call the `update` endpoint as such:
 
 ```js
 const myAutotask = {
@@ -153,7 +153,7 @@ An example response:
 
 The `autotasks/{id}` endpoint is used for deleting an Autotask via a `DELETE` request. The endpoint accepts an autotask Id.
 
-Using the `defender-autotask-client`, you can call the `delete` endpoint as such:
+Using the `@openzeppelin/defender-autotask-client`, you can call the `delete` endpoint as such:
 
 ```js
 await client.delete("671d1f80-99e3-4829-aa15-f01e3298e428");
@@ -184,7 +184,7 @@ curl \
     "https://defender-api.openzeppelin.com/autotask/autotasks/${AUTOTASKID}/code"
 ```
 
-Or through `defender-autotask-client` as such:
+Or through `@openzeppelin/defender-autotask-client` as such:
 
 ```js
 await client.updateCodeFromFolder("671d1f80-99e3-4829-aa15-f01e3298e428", './code');
@@ -208,7 +208,7 @@ curl \
     "https://defender-api.openzeppelin.com/autotask/autotasks/${AUTOTASKID}/runs/manual"
 ```
 
-Or through `defender-autotask-client` as such:
+Or through `@openzeppelin/defender-autotask-client` as such:
 
 ```js
 await client.runAutotask("671d1f80-99e3-4829-aa15-f01e3298e428");
@@ -263,7 +263,7 @@ curl \
     "https://defender-api.openzeppelin.com/autotask/secrets"
 ```
 
-Or through `defender-autotask-client` as shown below. Both the `deletes` array and `secrets` object are required to be present in the payload, but can contain empty values. For example, these calls are all valid:
+Or through `@openzeppelin/defender-autotask-client` as shown below. Both the `deletes` array and `secrets` object are required to be present in the payload, but can contain empty values. For example, these calls are all valid:
 
 ```js
 await client.createSecrets({ deletes: [], secrets: { foo: 'bar' } });

--- a/docs/modules/ROOT/pages/autotasks.adoc
+++ b/docs/modules/ROOT/pages/autotasks.adoc
@@ -53,7 +53,7 @@ If you connect your Autotask to a Relayer, then Defender will automatically inje
 
 [source,jsx]
 ----
-const { Relayer } = require('defender-relay-client');
+const { Relayer } = require('@openzeppelin/defender-relay-client');
  
 exports.handler = async function(event) {
   const relayer = new Relayer(event);
@@ -63,11 +63,11 @@ exports.handler = async function(event) {
 
 This allows you to send transactions using your Relayer from your Autotasks without having to set up any API keys or secrets. Furthermore, you can also use the Relayer JSON RPC endpoint for making queries to any Ethereum network without having to configure API keys for external network providers.
 
-If you want to https://www.npmjs.com/package/defender-relay-client#ethersjs[use `ethers.js`] for making queries or sending transactions via your Relayer, change the above to:
+If you want to https://www.npmjs.com/package/@openzeppelin/defender-relay-client#ethersjs[use `ethers.js`] for making queries or sending transactions via your Relayer, change the above to:
 
 [source,jsx]
 ----
-const { DefenderRelaySigner, DefenderRelayProvider } = require('defender-relay-client/lib/ethers');
+const { DefenderRelaySigner, DefenderRelayProvider } = require('@openzeppelin/defender-relay-client/lib/ethers');
 const ethers = require('ethers');
  
 exports.handler = async function(event) {
@@ -79,11 +79,11 @@ exports.handler = async function(event) {
 }
 ----
 
-And if you prefer https://www.npmjs.com/package/defender-relay-client#web3js[using `web3.js`], then use the following snippet:
+And if you prefer https://www.npmjs.com/package/@openzeppelin/defender-relay-client#web3js[using `web3.js`], then use the following snippet:
 
 [source,jsx]
 ----
-const { DefenderRelayProvider } = require('defender-relay-client/lib/web3');
+const { DefenderRelayProvider } = require('@openzeppelin/defender-relay-client/lib/web3');
 const Web3 = require('web3');
  
 exports.handler = async function(event) {
@@ -163,11 +163,11 @@ NOTE: While you can also use autotask secrets to store private keys for signing 
 
 The Autotask key-value data store allows you to persist simple data across Autotask runs and between different Autotasks. You can use it to store transaction identifiers, hashed user emails, or even small serialized objects.
 
-Access to the key value store is managed through the http://npmjs.com/package/defender-kvstore-client[`defender-kvstore-client`] package:
+Access to the key value store is managed through the http://npmjs.com/package/@openzeppelin/defender-kvstore-client[`@openzeppelin/defender-kvstore-client`] package:
 
 [source,jsx]
 ----
-const { KeyValueStoreClient } = require('defender-kvstore-client');
+const { KeyValueStoreClient } = require('@openzeppelin/defender-kvstore-client');
 
 exports.handler =  async function(event) {
   const store = new KeyValueStoreClient(event);
@@ -290,18 +290,20 @@ Autotasks are executed in a https://nodejs.org/dist/latest-v16.x/docs/api/[node 
 "@gnosis.pm/safe-ethers-adapters": "^0.1.0-alpha.3",
 "axios": "^0.27.2",
 "axios-retry": "3.1.9",
-"defender-admin-client": "1.37.0-rc.2",
-"defender-autotask-client": "1.37.0-rc.2",
-"defender-autotask-utils": "1.34.0",
-"defender-kvstore-client": "1.37.0-rc.2",
-"defender-relay-client": "1.37.0-rc.2",
-"defender-sentinel-client": "1.37.0-rc.2",
+"@openzeppelin/defender-admin-client": "1.52.0",
+"@openzeppelin/defender-autotask-client": "1.52.0",
+"@openzeppelin/defender-autotask-utils": "1.52.0",
+"@openzeppelin/defender-kvstore-client": "1.52.0",
+"@openzeppelin/defender-relay-client": "1.52.0",
+"@openzeppelin/defender-sentinel-client": "1.52.0",
 "ethers": "5.5.3",
 "fireblocks-sdk": "^2.5.4",
 "graphql": "^15.5.1",
 "graphql-request": "3.4.0",
 "web3": "1.9.0"
 ----
+
+WARNING: Defender dependencies that are not under the `@openzeppelin` namespace are now deprecated from the autotask runtime
 
 WARNING: Autotasks created with Node.js 12 runtime needs to be migrated to the latest supported runtime.
 
@@ -321,7 +323,7 @@ You can also use the following template for local development, which will run yo
 
 [source,jsx]
 ----
-const { Relayer } = require('defender-relay-client');
+const { Relayer } = require('@openzeppelin/defender-relay-client');
 
 // Entrypoint for the Autotask
 exports.handler = async function(event) {
@@ -343,11 +345,11 @@ if (require.main === module) {
 
 We love https://www.typescriptlang.org/[typescript] in the Defender development team, and we hope you do too! If you want to write your Autotasks in typescript, you'll need to first compile them using `tsc` or via your bundler of choice, and then upload the resulting javascript code. Unfortunately, we don't support coding directly in typescript in the Defender web interface.
 
-All `defender-client` packages are coded in typescript and are packaged with their type declarations. You can also use the https://www.npmjs.com/package/defender-autotask-utils[defender-autotask-utils] package for type definitions for the event payload.
+All `defender-client` packages are coded in typescript and are packaged with their type declarations. You can also use the https://www.npmjs.com/package/@openzeppelin/defender-autotask-utils[@openzeppelin/defender-autotask-utils] package for type definitions for the event payload.
 
 [source,ts]
 ----
-import { AutotaskEvent, SentinelTriggerEvent } from 'defender-autotask-utils';
+import { AutotaskEvent, SentinelTriggerEvent } from '@openzeppelin/defender-autotask-utils';
 
 // Example for an Autotask being triggered by a Sentinel
 export async function handler(event: AutotaskEvent) {
@@ -359,7 +361,7 @@ export async function handler(event: AutotaskEvent) {
 [[updating-code]]
 === Updating code
 
-You can edit an Autotask's code via the Defender webapp, or programmatically xref:autotasks-api-reference.adoc[via API] using the https://www.npmjs.com/package/defender-autotask-client[`defender-autotask-client`] npm package. The latter allows you to upload a code bundle with more than a single file:
+You can edit an Autotask's code via the Defender webapp, or programmatically xref:autotasks-api-reference.adoc[via API] using the https://www.npmjs.com/package/@openzeppelin/defender-autotask-client[`@openzeppelin/defender-autotask-client`] npm package. The latter allows you to upload a code bundle with more than a single file:
 
 ```bash
 $ echo API_KEY=$API_KEY >> .env
@@ -377,7 +379,7 @@ The following example uses ethers.js and the Autotask-Relayer integration to sen
 [source,jsx]
 ----
 const { ethers } = require("ethers");
-const { DefenderRelaySigner, DefenderRelayProvider } = require('defender-relay-client/lib/ethers');
+const { DefenderRelaySigner, DefenderRelayProvider } = require('@openzeppelin/defender-relay-client/lib/ethers');
 
 // Entrypoint for the Autotask
 exports.handler = async function(event) {

--- a/docs/modules/ROOT/pages/guide-balance-automation-forta-sentinel.adoc
+++ b/docs/modules/ROOT/pages/guide-balance-automation-forta-sentinel.adoc
@@ -17,7 +17,7 @@ You'll need to install the relevant Defender NPM packages. Note that Forta bot c
 ```
 $ mkdir minimum-balance && cd minimum-balance
 $ npm init -y
-$ npm i --save-dev defender-relay-client defender-autotask-client defender-sentinel-client dotenv
+$ npm i --save-dev @openzeppelin/defender-relay-client @openzeppelin/defender-autotask-client @openzeppelin/defender-sentinel-client dotenv
 ```
 
 [[create-relayer]]
@@ -25,10 +25,10 @@ $ npm i --save-dev defender-relay-client defender-autotask-client defender-senti
 
 From the Defender web interface, open the hamburger menu at the top right. Grab your Team API key and secret and save them to your local .env file.
 
-Using `defender-relay-client`, create a new https://docs.openzeppelin.com/defender/relay[Relayer] on the Polygon network and save the Relayer's ID to your `.env` file. 
+Using `@openzeppelin/defender-relay-client`, create a new https://docs.openzeppelin.com/defender/relay[Relayer] on the Polygon network and save the Relayer's ID to your `.env` file. 
 
 ```
-const { RelayClient } = require('defender-relay-client');
+const { RelayClient } = require('@openzeppelin/defender-relay-client');
 const { appendFileSync } = require('fs');
 
 async function run() {
@@ -85,10 +85,10 @@ async function handler(event) {
 
 The Autotask is able to connect to the Relayer by specifying its ID during Autotask creation. Credential passing is handled automatically and securely.
 
-Using https://www.npmjs.com/package/defender-autotask-client[`defender-autotask-client`], write a script in a separate file that creates a new Autotask and uploads the code from `autotasks/index.js`:
+Using https://www.npmjs.com/package/@openzeppelin/defender-autotask-client[`@openzeppelin/defender-autotask-client`], write a script in a separate file that creates a new Autotask and uploads the code from `autotasks/index.js`:
 
 ```
-const { AutotaskClient } = require('defender-autotask-client')
+const { AutotaskClient } = require('@openzeppelin/defender-autotask-client')
 const { appendFileSync } = require('fs')
 
 async function main() {
@@ -261,7 +261,7 @@ Using the `sentinel-client` package, write a script that creates a Forta Sentine
 
 ```
 require('dotenv').config()
-const { SentinelClient } = require('defender-sentinel-client')
+const { SentinelClient } = require('@openzeppelin/defender-sentinel-client')
 
 const BOT = process.env.BOT_ID
 

--- a/docs/modules/ROOT/pages/guide-factory.adoc
+++ b/docs/modules/ROOT/pages/guide-factory.adoc
@@ -7,15 +7,15 @@ This guide shows how you can use Defender to automate security monitoring for a 
 This automation is achieved through the following relationship between Defender components:
 
 * A Sentinel watches for every successful Event emitted by the contract that creates a clone. If detected, it triggers an Autotask to run and https://docs.openzeppelin.com/defender/sentinel#autotask_events[passes along information] about the transaction
-* The Autotask makes use of the https://www.npmjs.com/package/defender-admin-client[Admin API] to add the address of the newly created contract to Admin dashboard for easy monitoring of clone contract state
-* The Autotask uses the https://www.npmjs.com/package/defender-sentinel-client[Sentinel API] to add the clone address to the list of addresses watched by a Contract Sentinel
+* The Autotask makes use of the https://www.npmjs.com/package/@openzeppelin/defender-admin-client[Admin API] to add the address of the newly created contract to Admin dashboard for easy monitoring of clone contract state
+* The Autotask uses the https://www.npmjs.com/package/@openzeppelin/defender-sentinel-client[Sentinel API] to add the clone address to the list of addresses watched by a Contract Sentinel
 
 In this case, the contract ABI can be pre-supplied since clone contracts will have identical ABIs. Alternatively, you may be able to dynamically retrieve the ABI from a verified contract at a given address using https://docs.etherscan.io/api-endpoints/contracts[Etherscan’s API].
 
 [[generate-api-key]]
 == Generate API Key
 
-To programmatically add a contract to the Admin dashboard, the `defender-admin-client` API requires credentials in the form of an API key and secret.
+To programmatically add a contract to the Admin dashboard, the `@openzeppelin/defender-admin-client` API requires credentials in the form of an API key and secret.
 
 You can use an existing API key or create one to be used solely for this purpose.
 
@@ -40,7 +40,7 @@ Paste in the following Autotask code and hit Create.
 
 [source,js]
 ----
-const { AdminClient } = require('defender-admin-client')
+const { AdminClient } = require('@openzeppelin/defender-admin-client')
 
 exports.handler = async function (event) {
   const credentials = {
@@ -205,10 +205,10 @@ Add the https://github.com/offgridauthor/defender-admin-autoadd/blob/main/autota
 
 [source,js]
 ----
-const { SentinelClient } = require('defender-sentinel-client')
+const { SentinelClient } = require('@openzeppelin/defender-sentinel-client')
 ----
 
-The same API key used by `defender-admin-client` can be used, provided the key has the necessary permissions for editing Sentinels.
+The same API key used by `@openzeppelin/defender-admin-client` can be used, provided the key has the necessary permissions for editing Sentinels.
 
 Note that the `subscriberId` variable refers to the ID of the Sentinel. You can find this value by:
 

--- a/docs/modules/ROOT/pages/guide-metatx.adoc
+++ b/docs/modules/ROOT/pages/guide-metatx.adoc
@@ -102,7 +102,7 @@ Run `npx hardhat compile` to get the code ready for deployment.
 [[deploy-using-relayer]]
 == Deploy Using Relayer
 
-You can easily deploy a compiled smart contract without handling a private key by using https://www.npmjs.com/package/defender-relay-client[Defender Relayer client].
+You can easily deploy a compiled smart contract without handling a private key by using https://www.npmjs.com/package/@openzeppelin/defender-relay-client[Defender Relayer client].
 
 Create an instance of the `relay-client`, supplying the Relay's API key and secret as its credentials, and connect to it when calling `deploy()`.
 
@@ -143,7 +143,7 @@ It's important that the Relayer's API key and secret are insulated from the fron
 
 ```
 const ethers = require('ethers');
-const { DefenderRelaySigner, DefenderRelayProvider } = require('defender-relay-client/lib/ethers');
+const { DefenderRelaySigner, DefenderRelayProvider } = require('@openzeppelin/defender-relay-client/lib/ethers');
 
 const { ForwarderAbi } = require('../../src/forwarder');
 const ForwarderAddress = require('../../deploy.json').MinimalForwarder;
@@ -189,7 +189,7 @@ module.exports = {
 
 Note that the Autotask code must include an `index.js` file that exports a handler entrypoint. If the code relies on any external dependencies (such as an imported ABI) it's necessary to bundle the Autotask using webpack, rollup, etc.
 
-Although you can create an Autotask using the Defender web client, it may be more convenient to use a script that makes use of https://www.npmjs.com/package/defender-autotask-client[Defender's API].
+Although you can create an Autotask using the Defender web client, it may be more convenient to use a script that makes use of https://www.npmjs.com/package/@openzeppelin/defender-autotask-client[Defender's API].
 
 In the demo app, run `yarn create-autotask` to compile the Autotask code, create the Autotask in Defender and upload the bundled code by calling the Autotask client's `.create()` method:
 

--- a/docs/modules/ROOT/pages/guide-pauseguardian.adoc
+++ b/docs/modules/ROOT/pages/guide-pauseguardian.adoc
@@ -142,5 +142,5 @@ Now that all the building blocks have been laid, the system is ready to be teste
 == Resources
 
 * https://docs.openzeppelin.com/defender/sentinel[OpenZeppelin Defender Sentinel Documentation]
-* https://www.npmjs.com/package/defender-sentinel-client[OpenZeppelin Defender Sentinel Client API]
+* https://www.npmjs.com/package/@openzeppelin/defender-sentinel-client[OpenZeppelin Defender Sentinel Client API]
 * https://www.npmjs.com/package/@openzeppelin/wizard[OpenZeppelin Contracts Wizard API]

--- a/docs/modules/ROOT/pages/relay-api-reference.adoc
+++ b/docs/modules/ROOT/pages/relay-api-reference.adoc
@@ -15,9 +15,9 @@ The Relay API is split into 2 modules:
 
 For more information on authentication, refer to the xref:api-auth.adoc[authentication section].
 
-NOTE: You can use the https://www.npmjs.com/package/defender-relay-client[defender-relay-client] npm package for simplifying interactions with the Relay API.
+NOTE: You can use the https://www.npmjs.com/package/@openzeppelin/defender-relay-client[@openzeppelin/defender-relay-client] npm package for simplifying interactions with the Relay API.
 
-NOTE: It is not recommended to use the https://www.npmjs.com/package/defender-relay-client[defender-relay-client] npm package in a browser environment as sensitive keys would be exposed publicly.
+NOTE: It is not recommended to use the https://www.npmjs.com/package/@openzeppelin/defender-relay-client[@openzeppelin/defender-relay-client] npm package in a browser environment as sensitive keys would be exposed publicly.
 
 [[relay-client-module]]
 == Relay Client Module Reference
@@ -126,7 +126,7 @@ interface UpdateRelayerPoliciesRequest {
 include::partial$network.adoc[]
 ```
 
-Using the `defender-relay-client` package:
+Using the `@openzeppelin/defender-relay-client` package:
 
 ```js
 const requestParameters = {
@@ -230,7 +230,7 @@ interface UpdateRelayerRequest {
 }
 ```
 
-Using the `defender-relay-client` package:
+Using the `@openzeppelin/defender-relay-client` package:
 
 ```js
 await client.update('201832e2-c612-4283-97c5-31849242c1fe', { name: 'My Updated Name' });
@@ -249,7 +249,7 @@ curl \
     "https://defender-api.openzeppelin.com/relayer/relayers"
 ```
 
-NOTE: If making the request directly (not with `defender-relay-client`), any policy updates will need to be made via requests to the endpoint directly below with a body type of `UpdateRelayerPoliciesRequest`.
+NOTE: If making the request directly (not with `@openzeppelin/defender-relay-client`), any policy updates will need to be made via requests to the endpoint directly below with a body type of `UpdateRelayerPoliciesRequest`.
 
 ```
 curl \

--- a/docs/modules/ROOT/pages/relay.adoc
+++ b/docs/modules/ROOT/pages/relay.adoc
@@ -83,11 +83,11 @@ NOTE: Private transactions are only enabled for _goerli_ and _mainnet_ by using 
 [[sending-transactions]]
 == Sending transactions
 
-The easiest way to send a transaction via a Relayer is using the https://www.npmjs.com/package/defender-relay-client[`defender-relay-client`] npm package. The client is initialized with an API key/secret and exposes a simple API for sending transactions through the corresponding Relayer.
+The easiest way to send a transaction via a Relayer is using the https://www.npmjs.com/package/@openzeppelin/defender-relay-client[`@openzeppelin/defender-relay-client`] npm package. The client is initialized with an API key/secret and exposes a simple API for sending transactions through the corresponding Relayer.
 
 [source,jsx]
 ----
-import { Relayer } from 'defender-relay-client';
+import { Relayer } from '@openzeppelin/defender-relay-client';
 const relayer = new Relayer({apiKey: YOUR_API_KEY, apiSecret: YOUR_API_SECRET});
 
 const tx = await relayer.sendTransaction({
@@ -106,7 +106,7 @@ The Relayer client integrates with https://docs.ethers.io/v5/[ethers.js] via a c
 
 [source,jsx]
 ----
-const { DefenderRelaySigner, DefenderRelayProvider } = require('defender-relay-client/lib/ethers');
+const { DefenderRelaySigner, DefenderRelayProvider } = require('@openzeppelin/defender-relay-client/lib/ethers');
 const { ethers } = require('ethers');
  
 const credentials = { apiKey: YOUR_API_KEY, apiSecret: YOUR_API_SECRET };
@@ -120,7 +120,7 @@ const mined = await tx.wait();
 
 In the example above, we are also using a `DefenderRelayProvider` for making calls to the network. The Defender signer can work with any provider, such as `ethers.getDefaultProvider()`, but you can rely on Defender as a network provider as well. 
 
-You can read more about the ethers integration https://www.npmjs.com/package/defender-relay-client#user-content-ethersjs[here].
+You can read more about the ethers integration https://www.npmjs.com/package/@openzeppelin/defender-relay-client#user-content-ethersjs[here].
 
 [[using-web3.js]]
 === Using web3.js
@@ -129,7 +129,7 @@ The Relayer client integrates with https://web3js.readthedocs.io/[web3.js] as we
 
 [source,jsx]
 ----
-const { DefenderRelayProvider } = require('defender-relay-client/lib/web3');
+const { DefenderRelayProvider } = require('@openzeppelin/defender-relay-client/lib/web3');
 const Web3 = require('web3');
  
 const credentials = { apiKey: YOUR_API_KEY, apiSecret: YOUR_API_SECRET };
@@ -143,7 +143,7 @@ const tx = await erc20.methods.transfer(beneficiary, (1e18).toString()).send();
 
 In the example above, the `transfer` transaction is signed and broadcasted by the Defender Relayer, and any additional JSON RPC calls are routed via the Defender private endpoint.
 
-You can read more about the web3 integration https://www.npmjs.com/package/defender-relay-client#user-content-web3js[here].
+You can read more about the web3 integration https://www.npmjs.com/package/@openzeppelin/defender-relay-client#user-content-web3js[here].
 
 [[eip1559]]
 === EIP1559 support
@@ -225,7 +225,7 @@ NOTE: `validUntil` is a UTC timestamp. Make sure to use a UTC timezone and not a
 [[transaction-ids]]
 === Transaction IDs
 
-Since the Relayer may resubmit a transaction with an updated gas pricing if it does not get mined in the expected time frame, the `hash` of a given transaction may change over time. To track the status of a given transaction, the Relayer API returns a `transactionId` identifier you can use to https://www.npmjs.com/package/defender-relay-client#querying[query] it.
+Since the Relayer may resubmit a transaction with an updated gas pricing if it does not get mined in the expected time frame, the `hash` of a given transaction may change over time. To track the status of a given transaction, the Relayer API returns a `transactionId` identifier you can use to https://www.npmjs.com/package/@openzeppelin/defender-relay-client#querying[query] it.
 
 [source,jsx]
 ----
@@ -239,7 +239,7 @@ NOTE: The `query` endpoint will return the latest view of the transaction from t
 
 While a Defender Relay will automatically resubmit transactions with increased gas pricing if they are not mined, and will automatically cancel them after their valid-until timestamp, you can still manually replace or cancel your transaction if it has not been mined yet. This allows you to cancel a transaction if it is no longer valid, tweak its TTL, or bump its speed or gas pricing.
 
-To do this, use the `replaceByNonce` or `replaceById` of the `defender-relay-client`:
+To do this, use the `replaceByNonce` or `replaceById` of the `@openzeppelin/defender-relay-client`:
 
 [source,jsx]
 ----
@@ -371,7 +371,7 @@ A Relayer can be attached to an xref:autotask.adoc[Autotask], a code snippet tha
 
 [source,jsx]
 ----
-const { Relayer } = require('defender-relay-client');
+const { Relayer } = require('@openzeppelin/defender-relay-client');
 
 // The credentials object is injected by the Defender Autotasks engine 
 exports.handler = async function(credentials) {

--- a/docs/modules/ROOT/pages/sentinel-api-reference.adoc
+++ b/docs/modules/ROOT/pages/sentinel-api-reference.adoc
@@ -5,12 +5,12 @@ The Sentinel API allows you to programmatically create and manage sentinels.
 
 Requests need to be authenticated with a bearer token, which is negotiated from the Team API Key with the corresponding capability. Refer to the xref:api-auth.adoc[authentication section] for info on how to negotiate it.
 
-NOTE: We recommend you use the https://www.npmjs.com/package/defender-sentinel-client[defender-sentinel-client] npm package for simplifying interactions with the Sentinel API.
+NOTE: We recommend you use the https://www.npmjs.com/package/@openzeppelin/defender-sentinel-client[@openzeppelin/defender-sentinel-client] npm package for simplifying interactions with the Sentinel API.
 
-NOTE: It is not recommended to use the https://www.npmjs.com/package/defender-sentinel-client[defender-sentinel-client] npm package in a browser environment as sensitive keys would be exposed publicly.
+NOTE: It is not recommended to use the https://www.npmjs.com/package/@openzeppelin/defender-sentinel-client[@openzeppelin/defender-sentinel-client] npm package in a browser environment as sensitive keys would be exposed publicly.
 
 ```js
-const { SentinelClient } = require('defender-sentinel-client');
+const { SentinelClient } = require('@openzeppelin/defender-sentinel-client');
 const creds = { apiKey: ADMIN_API_KEY, apiSecret: ADMIN_API_SECRET };
 const client = new SentinelClient(creds);
 ```

--- a/docs/modules/ROOT/pages/sentinel.adoc
+++ b/docs/modules/ROOT/pages/sentinel.adoc
@@ -229,7 +229,7 @@ NOTE: Each invocation can contain up to 25 transactions.
 
 ==== Request Schema
 
-The request body will contain the following structure. You can use the `SentinelConditionRequest` type from the https://www.npmjs.com/package/defender-autotask-utils[defender-autotask-utils] package if you are coding your Autotasks in Typescript.
+The request body will contain the following structure. You can use the `SentinelConditionRequest` type from the https://www.npmjs.com/package/@openzeppelin/defender-autotask-utils[@openzeppelin/defender-autotask-utils] package if you are coding your Autotasks in Typescript.
 
 [source,jsx]
 ----
@@ -628,7 +628,7 @@ IMPORTANT: Autotask executions are subject to quotas. After a quota is exhausted
 
 == Autotask Events
 
-The sentinel will pass information about the transaction to your autotask. If you are writing your Autotasks in typescript you can use the `BlockTriggerEvent` type for contract sentinels and the `FortaTriggerEvent` type for Forta sentinels, from the https://www.npmjs.com/package/defender-autotask-utils[defender-autotask-utils] package.
+The sentinel will pass information about the transaction to your autotask. If you are writing your Autotasks in typescript you can use the `BlockTriggerEvent` type for contract sentinels and the `FortaTriggerEvent` type for Forta sentinels, from the https://www.npmjs.com/package/@openzeppelin/defender-autotask-utils[@openzeppelin/defender-autotask-utils] package.
 
 === Example Autotask
 


### PR DESCRIPTION
- Update autotask dependencies list
- Add warning that dependencies not under @openzeppelin namespace are been deprecated
- use @openzeppelin namespace name in all references