### PR TITLE
chore(deploy): Update upgrade script output

### DIFF
--- a/docs/modules/ROOT/pages/tutorial/deploy.adoc
+++ b/docs/modules/ROOT/pages/tutorial/deploy.adoc
@@ -398,7 +398,8 @@ async function main() {
 
   const proposal = await defender.proposeUpgradeWithApproval('<PROXY ADDRESS>', BoxV2);
 
-  console.log(`Upgrade proposed with URL: ${proposal.url}`);
+  console.log("Proposal id:", proposal.proposalId);
+  console.log("Url", proposal.url);
 }
 
 // We recommend this pattern to be able to use async/await everywhere


### PR DESCRIPTION
This PR will update hardhat upgrade script to log out proposal id as well.
This output will match foundry script output and be consistent.
Also given that we allow EOA upgrade approval process url is not always present so proposalId could be useful.